### PR TITLE
Add ability to limit the diagram to a specific class, it's direct parents and it's decendants

### DIFF
--- a/Project/Sources/Methods/Compiler_Methods.4dm
+++ b/Project/Sources/Methods/Compiler_Methods.4dm
@@ -1,0 +1,9 @@
+//%attributes = {"invisible":true}
+C_TEXT:C284(macro_csDiagram; $1)
+C_OBJECT:C1216(macro_csDiagram; $2)
+C_TEXT:C284(macro_csDiagram; $3)
+C_OBJECT:C1216(csDiagram; $0)
+C_OBJECT:C1216(csDiagram; $1)
+
+//csDiagram
+C_OBJECT:C1216(csDiagram; $2)

--- a/Project/Sources/Methods/csDiagram.4dm
+++ b/Project/Sources/Methods/csDiagram.4dm
@@ -1,3 +1,8 @@
 //%attributes = {"shared":true,"preemptive":"capable"}
-C_OBJECT:C1216($1;$0)
-$0:=cs:C1710.ClassStoreDiagram.new($1)
+C_OBJECT:C1216($1; $2; $0)
+If (Count parameters:C259=1)
+	$0:=cs:C1710.ClassStoreDiagram.new($1)
+End if 
+If (Count parameters:C259=2)
+	$0:=cs:C1710.ClassStoreDiagram.new($1; $2)
+End if 


### PR DESCRIPTION
I have a project that had a lot of classes and I am using your (very useful component) to generate diagrams.

I added the ability to cherry pick a particular class and have the diagram just limited to that classes direct parents and all of their descendants. Super useful in reducing the size of the graph.